### PR TITLE
0.5.3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,15 +104,10 @@ class Marimo {
                     // require the specified reporter
                     let Reporter = require('./reporters/' + message.reporter || 'basic');
 
-                    let env; 
+                    let env;
                     // extract any environment variables if they were sent (unless its been explicitly disabled) 
                     if (this.env !== false && this.env !== 'false') {
-                        try {
-                            env = message.env ? JSON.parse(message.env) : null;
-                        } catch (err) {
-                            ws.send(`error on parsing env variables, ignoring. err: ${err.message}`);
-                            debug(`error while trying to parse environment variables:\n${message.env}\n with error ${err.message}`);                    
-                        }
+                        env = message.env;
                     }
 
                     // run the test
@@ -146,8 +141,14 @@ class Marimo {
             if (env) {
                 debug('setting incoming environment variables');
                 Object.keys(env).forEach((key) => {
-                    process.env[test + '_' + key] = env[key];
-                    debug(`set ${test + '_' + key} = ${env[key]}`);
+                    if (env[key] instanceof Object) {
+                        debug(`set object ${test + '_' + key} = ${JSON.stringify(env[key])}`);
+                        process.env[test + '_' + key] = JSON.stringify(env[key]);
+                    }
+                    else {
+                        debug(`set object ${test + '_' + key} = ${env[key]}`);
+                        process.env[test + '_' + key] = env[key];                        
+                    }
                     environmentKeys.push(test + '_' + key);
                 });
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marimo",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "web hosting framework for mocha",
   "keywords":["mocha", "web sockets", "server", "websockets", "web", "ws", "hosted"],
   "main": "lib/index.js",

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ describe('my amazing test suite', () => {
     done();
   });
 });
+This file can also be found [here](https://github.com/lawrips/marimo/blob/master/samples/simple.js)
 
 ```
 4. You can now run the server:
@@ -98,6 +99,8 @@ node client.js
 ```
 
 ### Browser
+1. . Create a web based client to talk to marimo. This can be copied from the file browser.html found [here](https://github.com/lawrips/marimo/blob/master/samples/browser.html) (also pasted below)
+
 ```
 <script type="text/javascript">
   // on page load

--- a/samples/server.js
+++ b/samples/server.js
@@ -4,7 +4,7 @@ const Marimo = require('../lib/index');
 // this starts the server with auth enabled
 let marimo = new Marimo(
     {
-        auth: 'a-random-password' // remove this line to start marimo with auth disabled
+        // auth: 'a-random-password' // enable this line to start marimo with auth enabled
     }
 );
 

--- a/test/index.js
+++ b/test/index.js
@@ -102,6 +102,7 @@ var stubs = {
 };
 
 let success = false;
+let env; 
 stubs.mocha.Runner = function(suite) {
     return {
         run: function() {
@@ -177,6 +178,24 @@ describe('marimo unit tests', () => {
         success.should.be.equal(true);
         done();
         
+    });
+
+    it('simulate a request to run a test, sending some environment variables', (done) => {        
+        // when a client first connects, it receives a message with the list of available tests. we'll verify it matches
+        stubs.websocket.onMessage[0](JSON.stringify({"reporter":"basic", "test":testname, "env": {"myenvval":"myenvkey"}}));
+        'myenvkey'.should.be.equal(process.env[testname + '_' + 'myenvval']);
+        done();        
+    });
+
+    it('simulate a request to run a test, sending some more complex environment variables', (done) => {        
+        // when a client first connects, it receives a message with the list of available tests. we'll verify it matches
+        let envObj = {"mystuff": 
+            [{"myenvval1":"myenvkey1"},
+            {"myenvval2":"myenvkey2"}]
+        };
+        stubs.websocket.onMessage[0](JSON.stringify({"reporter":"basic", "test":testname, "env": envObj}));
+        JSON.stringify(envObj.mystuff).should.be.equal(process.env[testname + '_' + 'mystuff']);
+        done();        
     });
 
     it('running a test that does not exist should result in a 404', (done) => {        


### PR DESCRIPTION
Previous versions allow parameters to be sent and passed into the tests (which are stored as environment variables). However, this only worked for string values. This bug fix allows objects to be sent. For example the following will now work:
```
        let envObj = {"mystuff": 
            [{"myenvval1":"myenvkey1"},
            {"myenvval2":"myenvkey2"}]
        };
        w.send(JSON.stringify({"reporter":"basic", "test":testname, "env": envObj}));

```