### PR TITLE
0.6.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,10 @@ class Marimo {
         this.WebSocketServer = WebSocket.Server;
         this.wss = {};
         this.tokens = [];
+        
+        // monitoring tests (these run perpetually)
         this.monitors = [];
+        this.monitorOptions = {};
     }
 
     /**
@@ -98,7 +101,9 @@ class Marimo {
 
             debug(`incoming WebSocket request success`);
             if (monitor) {
-                ws.send(JSON.stringify({availableTests: this.tests}));
+                ws.send(JSON.stringify({
+                    availableTests: this.tests, 
+                    monitoringTests: this.monitorOptions.test ? this.monitorOptions.test.primary : null}));
                 this.monitors.push(ws);
             }
             else {
@@ -134,35 +139,17 @@ class Marimo {
                     // if this request to start a monitor style test 
                     if (message.monitor) {
                         if (message.monitor.cmd == 'start') {
-                            this.stop = false;
-                            // inject the array of websockets which have requested to be monitoring  
-                            let arrayOfWs = {
-                                monitors: this.monitors,
-                                send: (message) =>{
-                                    // iterate through all our monitoring websockets
-                                    for (let i=this.monitors.length -1; i>=0; i--) {
-                                        try {
-                                            // send the result of the test to each one
-                                            this.monitors[i].send(message);
-                                        } catch (ex) {
-                                            // if there is an error sending to one (e.g. ws was disconnected), remove it
-                                            debug(ex);
-                                            this.monitors.splice(i,1);
-                                        }
-                                    };
-                                }
-                            }
-
-                            this._runCycle(arrayOfWs, Reporter, message.test, env, message.delay);
+                            this._startMonitorTest(Reporter, message, env);
                         }
                         else if (message.monitor.cmd == 'stop') {
-                            // clear any existing monitor test
+                            // stop the existing monitor test
                             this.stop = true;
+                            this.monitorOptions.test.primary = null;
                         }
                     }
                     else {
                         // regular "run once" tests - much simpler flow
-                        this._run(ws, Reporter, message.test, env, () => {
+                        this._runOnce(ws, Reporter, message.test, env, () => {
                             // nothing to report
                         });
                     }                    
@@ -170,7 +157,7 @@ class Marimo {
                 } catch (err) {
                     // in the case of error loading the specific reporter
                     ws.send(`error loading reporter ${message.reporter}. err: ${err.message}`);
-                    debug(`error requiring reporter ${message.reporter}. err: ${err.message}`);                    
+                    debug(`error requiring reporter ${message.reporter}. err: ${err.message}`);  
                 }
             });
         });
@@ -179,23 +166,76 @@ class Marimo {
         this.wss.on('error', (err) => {
             debug('something went wrong: ' + err);
         });
-
     }
 
-    _runCycle(arrayOfWs, Reporter, test, env, delay) {
-        // now start a new monitor test 
-        this.monitorFunc = setTimeout(() => {
-            if (!this.stop) {
-                // run the test
-                this._run(arrayOfWs, Reporter, test, env, (err) => {
-                    // when tests are done, start over
-                    this._runCycle(arrayOfWs, Reporter, test, env)
-                });
+    _startMonitorTest(Reporter, message, env) {
+        this.stop = false;
+        // create a mock to replace the regular websocket. this overrides ws.send and will send to an array of connected websockets (i.e. broadcast)  
+        let monitorWs = {
+            monitors: this.monitors,
+            send: (message) =>{
+                // iterate through all our monitoring websockets
+                for (let i=this.monitors.length -1; i>=0; i--) {
+                    try {
+                        // send the result of the test to each one
+                        this.monitors[i].send(message);
+                    } catch (ex) {
+                        // if there is an error sending to one (e.g. ws was disconnected), remove it
+                        debug(ex);
+                        this.monitors.splice(i,1);
+                    }
+                };
             }
-        }, delay || 5000);        
+        }
+
+        // save options for the long running test
+        this.monitorOptions = {
+            test: {
+                // the main test to run
+                primary: !this.running ? message.test : this.monitorOptions.test.primary,
+                // if a test is already running, save this test to run after 
+                secondary: this.running ? message.test : null 
+            },
+            Reporter: Reporter,
+            env: env,
+            // the array of connected websockets who will be broadcast to
+            ws: monitorWs,
+            delay: message.delay || 5000
+        };
+
+        // check if there is already a test in progress
+        if (!this.running) {
+            this.running = true;
+            // no test in progress, start the test once immediately
+            this._runOnce(this.monitorOptions.ws, this.monitorOptions.Reporter, this.monitorOptions.test.primary, this.monitorOptions.env, (err) => {
+                // once it's completed, begin the loop
+                this._runAlways();
+            });
+        }
+        
     }
 
-    _run(ws, Reporter, test, env, callback) {
+    // recursive function which will keep a monitor style test alive
+    _runAlways() {
+        if (!this.stop) {
+            this.running = true;
+            this.monitorFunc = setTimeout(() => {
+                // run the test
+                this._runOnce(this.monitorOptions.ws, this.monitorOptions.Reporter, this.monitorOptions.test.primary, this.monitorOptions.env, (err) => {
+                    // when tests are done, start over
+                    this.running = false;
+                    // check to see if there is an alternative test waiting to run
+                    this.monitorOptions.test.primary = this.monitorOptions.test.secondary || this.monitorOptions.test.primary;
+                    this.monitorOptions.test.secondary = null;  
+
+                    // recurse / start over
+                    this._runAlways();                    
+                });
+            }, this.monitorOptions.delay);        
+        }            
+    }
+        
+    _runOnce(ws, Reporter, test, env, callback) {
         // uncache mocha - this is a workaround for the fact that mocha stores test state once require-d
         helper.uncache('mocha');
         let Mocha = require('mocha');
@@ -286,8 +326,6 @@ class Marimo {
         }
         return callback(true);
     }
-
-
 }
 
 module.exports = Marimo;

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ class Marimo {
         this.WebSocketServer = WebSocket.Server;
         this.wss = {};
         this.tokens = [];
+        this.monitors = [];
     }
 
     /**
@@ -91,11 +92,31 @@ class Marimo {
         // create WebSocket server
         this.wss = new this.WebSocketServer({ server: server, verifyClient: (info, callback) => this._verifyClient(info, callback) });
         this.wss.on('connection', (ws) => {
-            debug(`incoming WebSocket request success`);
-            // send the list of available tests
-            ws.send(JSON.stringify({availableTests: this.tests}));
+            let params = ws.upgradeReq.url.replace('/?', '');
+            // see if requesting client wants to listen for monitor tests only
+            let monitor = queryString.parse(params).monitor || false; 
 
-            // listen for messages
+            debug(`incoming WebSocket request success`);
+            if (monitor) {
+                ws.send(JSON.stringify({availableTests: this.tests}));
+                this.monitors.push(ws);
+            }
+            else {
+                // send the list of available tests
+                ws.send(JSON.stringify({availableTests: this.tests}));
+            }
+
+            // listen for messages. format is:
+            /* 
+            {
+                reporter: reporter,
+                test: test,
+                monitor: {
+                    cmd: [start|stop],
+                    delay: 1000
+                }
+            }
+            */
             ws.on('message', (data, flags) => {                
                 debug(`incoming WebSocket message: ${JSON.stringify(data)}`);
                 // parse incoming message
@@ -110,13 +131,46 @@ class Marimo {
                         env = message.env;
                     }
 
-                    // run the test
-                    this._run(ws, Reporter, message.test, env);                    
+                    // if this request to start a monitor style test 
+                    if (message.monitor) {
+                        if (message.monitor.cmd == 'start') {
+                            this.stop = false;
+                            // inject the array of websockets which have requested to be monitoring  
+                            let arrayOfWs = {
+                                monitors: this.monitors,
+                                send: (message) =>{
+                                    // iterate through all our monitoring websockets
+                                    for (let i=this.monitors.length -1; i>=0; i--) {
+                                        try {
+                                            // send the result of the test to each one
+                                            this.monitors[i].send(message);
+                                        } catch (ex) {
+                                            // if there is an error sending to one (e.g. ws was disconnected), remove it
+                                            debug(ex);
+                                            this.monitors.splice(i,1);
+                                        }
+                                    };
+                                }
+                            }
+
+                            this._runCycle(arrayOfWs, Reporter, message.test, env, message.delay);
+                        }
+                        else if (message.monitor.cmd == 'stop') {
+                            // clear any existing monitor test
+                            this.stop = true;
+                        }
+                    }
+                    else {
+                        // regular "run once" tests - much simpler flow
+                        this._run(ws, Reporter, message.test, env, () => {
+                            // nothing to report
+                        });
+                    }                    
 
                 } catch (err) {
                     // in the case of error loading the specific reporter
                     ws.send(`error loading reporter ${message.reporter}. err: ${err.message}`);
-                    debug(`error requiring reporter ${message.reporter} with ${err.message}`);                    
+                    debug(`error requiring reporter ${message.reporter}. err: ${err.message}`);                    
                 }
             });
         });
@@ -128,7 +182,20 @@ class Marimo {
 
     }
 
-    _run(ws, Reporter, test, env) {
+    _runCycle(arrayOfWs, Reporter, test, env, delay) {
+        // now start a new monitor test 
+        this.monitorFunc = setTimeout(() => {
+            if (!this.stop) {
+                // run the test
+                this._run(arrayOfWs, Reporter, test, env, (err) => {
+                    // when tests are done, start over
+                    this._runCycle(arrayOfWs, Reporter, test, env)
+                });
+            }
+        }, delay || 5000);        
+    }
+
+    _run(ws, Reporter, test, env, callback) {
         // uncache mocha - this is a workaround for the fact that mocha stores test state once require-d
         helper.uncache('mocha');
         let Mocha = require('mocha');
@@ -163,7 +230,9 @@ class Marimo {
             // create a test runner & reporter and run the test
             var runner = new Runner(mocha.suite);
             new Reporter(runner, ws, environmentKeys);
-            runner.run();
+            runner.run((err) => {
+                return callback(err);
+            });
         }
         else {
             debug(`did not find file for mocha test=${test}`);
@@ -210,7 +279,7 @@ class Marimo {
 
     _verifyClient(info, callback) {
         // check if authorization was set, if so - look for a valid token
-        let params = info.req.url.replace('/?', ''); 
+        let params = info.req.url.replace('/?', '');
         if (this.auth && this.tokens.indexOf(queryString.parse(params).token) == -1) {
             debug(`Unauthorized client connection for ${info.req.url}. Rejecting 401`)
             return callback(false, 401, "unauthorized");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marimo",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "web hosting framework for mocha",
   "keywords":["mocha", "web sockets", "server", "websockets", "web", "ws", "hosted"],
   "main": "lib/index.js",

--- a/samples/browser_monitor.html
+++ b/samples/browser_monitor.html
@@ -1,0 +1,118 @@
+<!-- EXAMPLE HTML PAGE WHICH CONNECTS TO MARIMO AND RUNS A TEST -->
+
+<!-- jquery not a must have, but pretty handy -->
+<script type="text/javascript" src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
+
+<div>
+	<span>
+        <h2>Test Suite</h2>
+    </span>
+</div>
+<div>
+	<span>
+        Choose a test:
+        </span>
+    <span>
+        <select id="testSelection">
+        </select>
+    </span>
+</div>
+<br>
+<div>
+	<span>
+        Choose a reporter:
+    </span>
+	<span>
+        <select id="reporterSelection">
+            <option value="json-stream"/>json-stream</option>
+        </select>
+    </span>
+</div>
+<br>
+<div>
+    <span> <input id="testButton" type="submit" value="Run Test" /> </span>
+    <span> <input id="stopButton" type="submit" value="Stop Test" /> </span>
+</div>
+<br>
+<div>
+	<span>
+        Test results:
+    </span>
+	<br>
+	<textarea rows="10" cols="80" id="testResults">
+Your test results will appear here
+    </textarea>
+</div>
+
+<script type="text/javascript">
+    // connect to your server running marimo (in this case localhost and port 10001)
+    socket = new WebSocket("ws://localhost:10001/?monitor=true");
+    var availableTests = null;
+    var iteration = 0;
+	
+    // open the socket connection
+    socket.onopen = function (event) {				
+        // raise events on incoming messages
+        socket.onmessage = function (event) {
+            // the first message we receive back is the list of available tests
+            if (!availableTests) {
+                // set this - subsequent messages will be the test results themselves  
+                availableTests = JSON.parse(event.data).availableTests;
+                // populate your UX with available tests (e.g. a drop down list)
+                $('#testSelection').empty();
+                Object.keys(availableTests).forEach((test) => { 
+                    $("#testSelection").append(
+                        $("<option>").val(test).html(availableTests[test].description)
+                    );
+                });
+            }
+            else {
+                var message = JSON.parse(event.data);
+                // new test started
+                if (message[0] == 'start') {
+                    $('#testResults').html($('#testResults').val() + "\n" + `************ iteration ${++iteration} ************`)
+                }
+                // any subsequent messages are the actual test results themselves - now update the UX with the results
+                if (event.data.indexOf('&#8226;') > -1) {
+                    // the presence of this unicode character tells us it's a "landing strip" reporter - overwrite the UX
+                    $('#testResults').html( event.data );
+                }
+                else  {
+                    // all other tests can be appended
+                    $('#testResults').html($('#testResults').val() + "\n" + event.data );
+                }
+                $('#testResults').scrollTop($('#testResults')[0].scrollHeight);
+
+            }
+        };
+    };
+    socket.onerror = function (event) {				
+        $('#testResults').html( event.data );
+    }
+
+
+    // So we can run tests
+    $('#testButton').click(function() {
+        // reset the results textbox        
+        $('#testResults').html(''); 
+        // run the test!
+        socket.send(JSON.stringify({
+                // get the test that was selected
+                test: $('#testSelection').find(":selected").val(),			
+                reporter: $('#reporterSelection').find(":selected").val(),
+                monitor: {cmd: 'start'}
+        }))
+    }); 
+
+    // So we can stop tests
+    $('#stopButton').click(function() {
+        iteration = 0;
+        // run the test!
+        socket.send(JSON.stringify({
+                // get the test that was selected
+                test: $('#testSelection').find(":selected").val(),			
+                reporter: $('#reporterSelection').find(":selected").val(),
+                monitor: {cmd: 'stop'}
+        }))
+    }); 
+</script>

--- a/samples/browser_monitor.html
+++ b/samples/browser_monitor.html
@@ -59,18 +59,25 @@ Your test results will appear here
                 // set this - subsequent messages will be the test results themselves  
                 availableTests = JSON.parse(event.data).availableTests;
                 // populate your UX with available tests (e.g. a drop down list)
+
                 $('#testSelection').empty();
                 Object.keys(availableTests).forEach((test) => { 
                     $("#testSelection").append(
                         $("<option>").val(test).html(availableTests[test].description)
                     );
                 });
+
+                // if we also received any notice of any monitoring style tests that are currently running
+                if (JSON.parse(event.data).monitoringTests) {
+                        $('#testResults').html($('#testResults').val() + "\n" + JSON.stringify(JSON.parse(event.data).monitoringTests) );
+                }
+
             }
             else {
                 var message = JSON.parse(event.data);
                 // new test started
                 if (message[0] == 'start') {
-                    $('#testResults').html($('#testResults').val() + "\n" + `************ iteration ${++iteration} ************`)
+                    $('#testResults').html($('#testResults').val() + "\n" + `************ Start: iteration ${++iteration} ************`)
                 }
                 // any subsequent messages are the actual test results themselves - now update the UX with the results
                 if (event.data.indexOf('&#8226;') > -1) {
@@ -82,6 +89,9 @@ Your test results will appear here
                     $('#testResults').html($('#testResults').val() + "\n" + event.data );
                 }
                 $('#testResults').scrollTop($('#testResults')[0].scrollHeight);
+                if (message[0] == 'end') {
+                    $('#testResults').html($('#testResults').val() + "\n" + `************ End: iteration ${iteration} ************`)
+                }
 
             }
         };

--- a/test/index.js
+++ b/test/index.js
@@ -88,6 +88,9 @@ var stubs = {
     websocket : {
         lastSentMessage: '',
         onMessage: [],
+        upgradeReq: {
+            url: ''
+        },
         on: function(event, callback) {
             if (event === 'message') {
                 debug('client registering websocket.on(message) callback');
@@ -176,6 +179,8 @@ describe('marimo unit tests', () => {
         // when a client first connects, it receives a message with the list of available tests. we'll verify it matches
         stubs.websocket.onMessage[0](JSON.stringify({"reporter":"basic", "test":testname}));
         success.should.be.equal(true);
+        // reset success
+        success = false;
         done();
         
     });
@@ -195,6 +200,15 @@ describe('marimo unit tests', () => {
         };
         stubs.websocket.onMessage[0](JSON.stringify({"reporter":"basic", "test":testname, "env": envObj}));
         JSON.stringify(envObj.mystuff).should.be.equal(process.env[testname + '_' + 'mystuff']);
+        done();        
+    });
+
+    it('simulate a request to run in monitor mode (i.e. perpetually running)', (done) => {        
+        // set request params so that the monitor code path is triggered
+        stubs.websocket.upgradeReq.url = '/?monitor=true';
+        stubs.websocket.onMessage[0](JSON.stringify({"reporter":"basic", "test":testname}));
+        success.should.be.equal(true);
+        // todo: trigger an array of connected websockets with a single test
         done();        
     });
 


### PR DESCRIPTION
New feature which:
- Allows tests to be run on continuous repeat. This enables monitoring / alerting scenarios. For example, a test to check for a 200 response code on a REST API can be run on repeat, and you can alert on the presence of an error. 
- Allows WebSocket clients to connect to marimo with a flag (monitor=true). Marimo will broadcast any continuous / repeating tests to just these clients. 