### PR TITLE
1.4.3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,8 +159,8 @@ class Marimo {
                 let message = JSON.parse(data);
                 try {                    
                     // inherit this process' environment options
-                    let env = process.env;
-
+                    let env = JSON.parse(JSON.stringify(process.env));
+                    
                     // extract any environment variables if they were sent (unless its been explicitly disabled) 
                     if (this.env !== false && this.env !== 'false') {
                         // merge them with environment variables

--- a/lib/modules/processManager.js
+++ b/lib/modules/processManager.js
@@ -58,7 +58,7 @@ function run(port) {
 }
 
 
-// listen for stop messages from parent 
+// listen for messages from parent (either a free port or a stop) 
 process.on('message', (m) => {
     if (m.split('=')[0] == 'port') {
         // free TCP port received from parent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marimo",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "run your tests on the web",
   "keywords": [
     "mocha",

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -73,6 +73,39 @@ describe('marimo e2e tests', () => {
         
     });
 
+    it('don\'t send any environment variables and check a test designed to read them failed', (done) => {
+        var ws = new WebSocket(`ws://localhost:13000`);        
+
+        ws.on('open', () => {
+            ws.send(JSON.stringify(
+                {
+                    reporter: 'json-stream-detail',
+                    test: 'simple'
+                })
+            );            
+        });
+
+        var started = false;
+        ws.on('message', (data, flags) => {
+            var result = JSON.parse(data);
+            if (!result.availableTests) {
+                if (!started) {
+                    result[0].should.equal('start');
+                    started = true;
+                }
+                else if (result[0] == 'end') {
+                    result[1].suites.should.equal(1);
+                    result[1].tests.should.equal(5);
+                    result[1].passes.should.be.equal(3); // should be 3 passes
+                    result[1].failures.should.be.equal(2); // should be 2 failures
+                    done();
+                }
+            }        
+        });
+        
+    });
+
+
     it('connect to web socket (auth) and check simple is in the available tests', (done) => {        
         http('http://localhost:14000/auth', {
             method: 'get',
@@ -143,10 +176,10 @@ describe('marimo e2e tests', () => {
                             }
                         })
                     );
-                    // after sending stop, wait 1.5s before completing test
+                    // after sending stop, wait 2s before completing test
                     setTimeout(() => {
                         done();
-                    }, 1500);                    
+                    }, 2000);                    
                 }
             }        
         });

--- a/test/forever.js
+++ b/test/forever.js
@@ -12,7 +12,8 @@ const should = require('should'),
 const filename = 'simple.js';
 let testname = filename.slice(0,filename.length-3);
 
-const numTimes = 1000000;
+// change this to the # of times you want to run a test for (can be a v large nuber for stability tests)
+const numTimes = 10;
 
 describe('marimo e2e test that runs perpatually (to test stability)', () => {
     before('start a marimo servers ', (done) => {        

--- a/test/index.js
+++ b/test/index.js
@@ -190,6 +190,9 @@ describe('marimo unit tests', () => {
     });
 
     it('simulate a request to run a test, sending some environment variables', (done) => {        
+        // set env variable
+        process.env['myenvkey'] = 'myenvval';
+
         stubs.websocket.onMessage[0](JSON.stringify({"reporter":"basic", "test":testname, "env": {"myenvkey":"myenvval"}}));
         'myenvval'.should.be.equal(process.env['myenvkey']);
         done();        
@@ -200,6 +203,10 @@ describe('marimo unit tests', () => {
             [{"myenvval1":"myenvkey1"},
             {"myenvval2":"myenvkey2"}]
         };
+
+        // set env variable
+        process.env["mystuff"] = JSON.stringify(envObj["mystuff"]);
+        
         stubs.websocket.onMessage[0](JSON.stringify({"reporter":"basic", "test":testname, "env": {mystuff :JSON.stringify(envObj.mystuff)}}));
         JSON.stringify(envObj.mystuff).should.be.equal(process.env['mystuff']);
         done();        


### PR DESCRIPTION
Fixing a bug which would cause environment variables passed up from a 'run test' command to be remembered between tests. This was a bug - environment variables passed up should only be valid for the purpose of a single test run. 