### PR TITLE
1.5.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,9 @@ class Marimo {
         this.portRange = options.debugPortRange || defaults.portRange;        
         this.maxPort = this.basePort + this.portRange;
         this.portFinder = new PortFinder({basePort: this.basePort, maxPort: this.maxPort, portRange: this.portRange});
+        
+        // debug mode will be automatically detected based on whether the original node process was started with this option 
+        this.debug = process.execArgv.map((arg) => arg.startsWith('--debug')).indexOf(true) > -1 ? true : false;
 
         // created a stubbed WS. This will be used for monitor-style tests, to broadcast to all connected websockets
         this.monitorWs = {
@@ -269,10 +272,7 @@ class Marimo {
             debug(`did not find file for mocha test=${test}`);
             ws.send(JSON.stringify({statusCode: 404}));
             return callback(new Error({statusCode: 404}));
-        }
-        // load the script
-        let script = path.join(path.dirname(fs.realpathSync(__filename)), './modules/runners/processManager.js');
-        
+        }        
         // create environment variables that will be passed to the child process
         env.marimo_test = this.tests[test].file;
         env.marimo_type = this.tests[test].type;
@@ -287,55 +287,70 @@ class Marimo {
         let options = {                 
             env: env
         };
+
+        if (delay) {
+            // if it's a monitoring style test, track it
+            this.processes[test] = process;
+        }
     
-        this.portFinder.getFreePort((err, port) => {
-            if (err) {
-                debug(`error from getFreePort: ${err}`);
-                return callback(err);
-            }
-
-            options.execArgv = ['--debug=' + port]; 
-            
-            // create a child process & fork it
-            let childProcess = require('child_process');
-            let process = childProcess.fork(script, options);
-            
-            if (delay) {
-                // if it's a monitoring style test, track it
-                this.processes[test] = process;
-            }
-
-            process.on('error', function (err) {
-                debug(`error from childProcess: ${err}`);
-                return callback(err);
-            });
-
-            // receive messages from child process
-            process.on('message', (data) => {
-                if (data == 'command=getport') {
-                    // system messages 
-                    this.portFinder.getFreePort((err, port) => {
-                        process.send('port=' + port);
-                    });
+        if (this.debug) {
+            this.portFinder.getFreePort((err, port) => {
+                if (err) {
+                    debug(`error from getFreePort: ${err}`);
+                    return callback(err);
                 }
-                else {
-                    // messages received back from child processes are sent to the websocket
-                    try {
-                        ws.send(data);
-                    } catch (ex) {
-                        debug(`error sending to websocket: ${ex}`);
-                    }
-                }
-            });
 
-            // exit callback once test is done
-            process.on('exit', function (code) {
-                var err = code === 0 ? null : new Error('exit code ' + code);
-                return callback();
+                this._runProcess(ws, options, test, port, callback);
             });
-
-        });
+        }
+        else {
+            this._runProcess(ws, options, test, null, callback);
+        }
     }            
+
+    _runProcess(ws, options, test, port, callback) {
+        // load the script
+        let script = path.join(path.dirname(fs.realpathSync(__filename)), './modules/runners/processManager.js');
+
+        // only start in debug mode if its been enabled for this server
+        if (this.debug) {
+            options.execArgv = ['--debug=' + port];
+        } 
+        
+        // create a child process & fork it
+        let childProcess = require('child_process');
+        let process = childProcess.fork(script, options);
+        
+        process.on('error', function (err) {
+            debug(`error from childProcess: ${err}`);
+            return callback(err);
+        });
+
+        // receive messages from child process
+        process.on('message', (data) => {
+            if (data == 'command=getport') {
+                // system messages 
+                this.portFinder.getFreePort((err, port) => {
+                    process.send('port=' + port);
+                });
+            }
+            else {
+                // messages received back from child processes are sent to the websocket
+                try {
+                    ws.send(data);
+                } catch (ex) {
+                    debug(`error sending to websocket: ${ex}`);
+                }
+            }
+        });
+
+        // exit callback once test is done
+        process.on('exit', function (code) {
+            var err = code === 0 ? null : new Error('exit code ' + code);
+            return callback();
+        });
+        
+    }
 
     _verifyClient(info, callback) {
         // check if authorization was set, if so - look for a valid token

--- a/lib/modules/loaders/fileLoader.js
+++ b/lib/modules/loaders/fileLoader.js
@@ -36,12 +36,12 @@ class FileLoader {
             if (this.directory != defaults.directory) 
             {
                 // directory was set and not found, throw exception
-                let error = `error on loading tests from directory ${this.directory}. Constructor must be initialized with a valid 'directory' property to load local tests`; 
+                let error = `error on loading tests from directory ${this.directory}. Constructor must be initialized with a valid 'directory' property to load local tests. Error: ${ex}`; 
                 throw new LoadException(error);
             }
             else {
                 // direcotry was not set and not found, just continue
-                let error = `error on loading tests from directory ${this.directory}. Marimo will continue but requires ./resources directory to exist, or constructor must be initialized with a valid 'directory' property to load local tests`; 
+                let error = `error on loading tests from directory ${this.directory}. Marimo will continue but requires ./resources directory to exist, or constructor must be initialized with a valid 'directory' property to load local tests. Error: ${ex}`; 
                 debug(`${error}`);
             }
         }

--- a/lib/modules/runners/processManager.js
+++ b/lib/modules/runners/processManager.js
@@ -23,18 +23,33 @@ let options = {
     env: JSON.parse(JSON.stringify(process.env))
 };
 
-// start by requesting a free port from the parent
-process.send('command=getport');
+// debug mode will be automatically detected based on whether the original node process was started with this option 
+let debugMode = process.execArgv.map((arg) => arg.startsWith('--debug')).indexOf(true) > -1 ? true: false;
+
+if (debugMode) {
+    // if debugging is enabled, we must first request a prot
+    process.send('command=getport');
+}
+else {
+    // no debug - we can just run 
+    run();
+}
 
 function run(port) {
-    options.execArgv = ['--debug=' + port]; 
-//    options.silent = true;
-    debug('Using port: ' + port);
+    if (debugMode) {
+        options.execArgv = ['--debug=' + port];
+        debug('Using port: ' + port);
+    } 
+    else {
+        debug('Debugging disabled');        
+    }
+
     // create a child process & fork it
     let childProcess = require('child_process');
     let child  = childProcess.fork(script, options);
 
     // do this for tape
+//    options.silent = true;
 /*    child.stdout.on('data', (data) => {
         try {
             let output = new Buffer(data).toString('utf-8');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marimo",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "run your tests on the web",
   "keywords": [
     "mocha",


### PR DESCRIPTION
Prior to 1.5.2, debug mode was enabled by default. it is now inherited from the parent process.

If the node app requiring marimo is started with --debug, then marimo will enable its port    management features to rotate debug ports when launching tests. Debug is enabled whenever node is started with --debug (or --debug-brk) or when started within certain editors (e.g. vscode).

If --debug is not enabled from the parent node app, then it is disabled through marimo.