### PR TITLE
1.5.3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ class Marimo {
      * @constructor
      * @param {Object} options - startup options passed to this instance
      * @param {string} [options.directory=./resources] -  Resource directory to locate the test files. Default is ./resources
-     * @param {Number} [options.timeout=10000] - How long to wait in ms before failing a test due to timeout (default 10000)
+     * @param {Number} [options.timeout=60000] - How long to wait in ms before failing a test due to timeout (default 10000)
      * @param {Number} [options.debugPort=12141] - The starting port which will be used for the debugger when launching mocha
      * @param {Number} [options.debugPortRange=100] - The number of ports available to cycle through mocha tests (to avoid port collisions)  
      * @param {string} [options.auth] - An optional password. If set, HTTP auth negotiation is required (refer to documentation for howto) 

--- a/lib/index.js
+++ b/lib/index.js
@@ -288,11 +288,6 @@ class Marimo {
             env: env
         };
 
-        if (delay) {
-            // if it's a monitoring style test, track it
-            this.processes[test] = process;
-        }
-    
         if (this.debug) {
             this.portFinder.getFreePort((err, port) => {
                 if (err) {
@@ -300,15 +295,15 @@ class Marimo {
                     return callback(err);
                 }
 
-                this._runProcess(ws, options, test, port, callback);
+                this._runProcess(ws, options, test, port, delay, callback);
             });
         }
         else {
-            this._runProcess(ws, options, test, null, callback);
+            this._runProcess(ws, options, test, null, delay, callback);
         }
     }            
 
-    _runProcess(ws, options, test, port, callback) {
+    _runProcess(ws, options, test, port, delay, callback) {
         // load the script
         let script = path.join(path.dirname(fs.realpathSync(__filename)), './modules/runners/processManager.js');
 
@@ -320,6 +315,13 @@ class Marimo {
         // create a child process & fork it
         let childProcess = require('child_process');
         let process = childProcess.fork(script, options);
+
+        if (delay) {
+            // if it's a monitoring style test, track it
+            this.processes[test] = process;
+        }
+    
+
         
         process.on('error', function (err) {
             debug(`error from childProcess: ${err}`);

--- a/lib/modules/runners/processManager.js
+++ b/lib/modules/runners/processManager.js
@@ -18,6 +18,21 @@ else {
 }
 
 let delay = process.env.marimo_delay;
+let alive = new Date()
+let child;
+
+// if we are monitoring
+if (delay) {
+    setInterval(() => {
+        // see if we've run in the last n seconds'
+        debug(`Last message on child process received ${(new Date().getTime() - alive.getTime()) / 1000}s ago. Compared to threshold of ${(Number.parseInt(delay) + Number.parseInt(process.env.marimo_timeout)) / 1000}s`);
+        if (new Date().getTime() - alive.getTime() > (Number.parseInt(delay) + Number.parseInt(process.env.marimo_timeout))) {
+            debug('Test took too long to respond, killing the process');
+            alive = new Date();
+            child.kill('SIGINT');
+        }
+    }, 60000);
+}
 
 let options = {                 
     env: JSON.parse(JSON.stringify(process.env))
@@ -26,13 +41,17 @@ let options = {
 // debug mode will be automatically detected based on whether the original node process was started with this option 
 let debugMode = process.execArgv.map((arg) => arg.startsWith('--debug')).indexOf(true) > -1 ? true: false;
 
-if (debugMode) {
-    // if debugging is enabled, we must first request a prot
-    process.send('command=getport');
-}
-else {
-    // no debug - we can just run 
-    run();
+initialize();
+
+function initialize() {
+    if (debugMode) {
+        // if debugging is enabled, we must first request a prot
+        process.send('command=getport');
+    }
+    else {
+        // no debug - we can just run 
+        run();
+    }    
 }
 
 function run(port) {
@@ -46,9 +65,9 @@ function run(port) {
 
     // create a child process & fork it
     let childProcess = require('child_process');
-    let child  = childProcess.fork(script, options);
+    child  = childProcess.fork(script, options);
 
-    // do this for tape
+    // future functionality to support tape
 //    options.silent = true;
 /*    child.stdout.on('data', (data) => {
         try {
@@ -66,14 +85,15 @@ function run(port) {
     });
 
     // messages received back from child processes are sent to the websocket
-    // do this for everyone else
     child.on('message', (data) => {
+        alive = new Date();        
         try {
             process.send(data);
         } catch (ex) {
             debug(`error sending to websocket: ${ex}`);
         }
     });
+
 
     // exit callback once test is done
     child.on('exit', (code) => {
@@ -82,7 +102,7 @@ function run(port) {
         // if this test was initialized with a delay, run it monitoring style
         if (delay) {
             setTimeout(() => {
-                process.send('command=getport');
+                initialize();
             }, delay);
         }
         else {

--- a/lib/modules/utils/defaults.js
+++ b/lib/modules/utils/defaults.js
@@ -1,5 +1,5 @@
 module.exports = {
-    timeout: 10000,
+    timeout: 60000,
 
     directory: './resources',
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marimo",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "run your tests on the web",
   "keywords": [
     "mocha",
@@ -27,7 +27,7 @@
     "express": "^4.13.4",
     "lodash": "^4.13.1",
     "mocha": "^2.5.3",
-    "newman": "3.0.0-beta.5",
+    "newman": "3.0.0",
     "newman-reporter-basic": "^0.0.2",
     "newman-reporter-json-stream-detail": "^0.0.2",
     "portfinder": "^1.0.3",

--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ let marimo = new Marimo({
   // optional path to test files (default is './resources')		
   directory: './mypath', 
 
-  // optional timeout in milliseconds (default is 10000)
+  // optional timeout in milliseconds (default is 60000)
   timeout: 2000,
 
   // optional starting port which will be used for the debugger when launching mocha (default is 12141)


### PR DESCRIPTION
- Additional process management control where tests that do not update by the specified timeout are killed. This increases stability of long running monitoring tests
- Increased default timeout to 60s for tests (was 10s). Can still be overridden in the marimo constructor
- Bumped support for Newman to 3.0.0
